### PR TITLE
Add macie-account module

### DIFF
--- a/.github/labeler.yaml
+++ b/.github/labeler.yaml
@@ -7,3 +7,5 @@
 - modules/config-recorder/**/*
 ":floppy_disk: config-managed-rule":
 - modules/config-managed-rule/**/*
+":floppy_disk: macie-account":
+- modules/macie-account/**/*

--- a/.github/labels.yaml
+++ b/.github/labels.yaml
@@ -52,3 +52,6 @@
 - color: "fbca04"
   description: "This issue or pull request is related to config-managed-rule module."
   name: ":floppy_disk: config-managed-rule"
+- color: "fbca04"
+  description: "This issue or pull request is related to macie-account module."
+  name: ":floppy_disk: macie-account"

--- a/examples/macie-account-simple/main.tf
+++ b/examples/macie-account-simple/main.tf
@@ -1,0 +1,20 @@
+provider "aws" {
+  region = "us-east-1"
+}
+
+
+###################################################
+# Macie Account
+###################################################
+
+module "account" {
+  source = "../../modules/macie-account"
+  # source  = "tedilabs/security/aws//modules/macie-account"
+  # version = "~> 0.5.0"
+
+  enabled = true
+
+  tags = {
+    "project" = "terraform-aws-secret-examples"
+  }
+}

--- a/examples/macie-account-simple/outputs.tf
+++ b/examples/macie-account-simple/outputs.tf
@@ -1,0 +1,3 @@
+output "account" {
+  value = module.account
+}

--- a/examples/macie-account-simple/versions.tf
+++ b/examples/macie-account-simple/versions.tf
@@ -1,0 +1,10 @@
+terraform {
+  required_version = "~> 1.2"
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 4.0"
+    }
+  }
+}

--- a/modules/macie-account/README.md
+++ b/modules/macie-account/README.md
@@ -1,0 +1,63 @@
+# macie-account
+
+This module creates following resources.
+
+- `aws_macie2_account`
+- `aws_macie2_member` (optional)
+- `aws_macie2_classification_export_configuration` (optional)
+
+<!-- BEGINNING OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
+## Requirements
+
+| Name | Version |
+|------|---------|
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.2 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 4.14 |
+
+## Providers
+
+| Name | Version |
+|------|---------|
+| <a name="provider_aws"></a> [aws](#provider\_aws) | 4.25.0 |
+
+## Modules
+
+No modules.
+
+## Resources
+
+| Name | Type |
+|------|------|
+| [aws_macie2_account.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/macie2_account) | resource |
+| [aws_macie2_classification_export_configuration.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/macie2_classification_export_configuration) | resource |
+| [aws_macie2_member.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/macie2_member) | resource |
+| [aws_resourcegroups_group.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/resourcegroups_group) | resource |
+| [aws_caller_identity.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/caller_identity) | data source |
+
+## Inputs
+
+| Name | Description | Type | Default | Required |
+|------|-------------|------|---------|:--------:|
+| <a name="input_discovery_result"></a> [discovery\_result](#input\_discovery\_result) | (Optional) The configuration for discovery result location and encryption of the macie account. A `discovery_result` block as defined below.<br>    (Required) `s3_bucket` - The name of the S3 bucket in which Amazon Macie exports the data discovery result.<br>    (Optional) `s3_key_prefix` - The key prefix for the specified S3 bucket. Defaults to `""`.<br>    (Required) `encryption_kms_key` - The Amazon Resource Name (ARN) of the KMS key to be used to encrypt the data. | `map(any)` | `null` | no |
+| <a name="input_enabled"></a> [enabled](#input\_enabled) | (Optional) Whether to enable Amazon Macie and start all Macie activities for the account. Defaults to `true`. Set `false` to suspend Macie, it stops monitoring your AWS environment and does not generate new findings. The existing findings remain intact and are not affected. Delete `aws_macie2_account` resource to disable Macie, it permanently deletes all of your existing findings, classification jobs, and other Macie resources. | `bool` | `true` | no |
+| <a name="input_member_accounts"></a> [member\_accounts](#input\_member\_accounts) | (Optional) A list of configurations for member accounts on the macie account. Each block of `member_accounts` as defined below.<br>    (Required) `account_id` -<br>    (Required) `email` -<br>    (Optional) `enabled` - Whether to enable Amazon Macie and start all Macie activities for the member account.<br>    (Optional) `tags` - A map of key-value pairs that specifies the tags to associate with the account in Amazon Macie. | `any` | `[]` | no |
+| <a name="input_module_tags_enabled"></a> [module\_tags\_enabled](#input\_module\_tags\_enabled) | (Optional) Whether to create AWS Resource Tags for the module informations. | `bool` | `true` | no |
+| <a name="input_resource_group_description"></a> [resource\_group\_description](#input\_resource\_group\_description) | (Optional) The description of Resource Group. | `string` | `"Managed by Terraform."` | no |
+| <a name="input_resource_group_enabled"></a> [resource\_group\_enabled](#input\_resource\_group\_enabled) | (Optional) Whether to create Resource Group to find and group AWS resources which are created by this module. | `bool` | `true` | no |
+| <a name="input_resource_group_name"></a> [resource\_group\_name](#input\_resource\_group\_name) | (Optional) The name of Resource Group. A Resource Group name can have a maximum of 127 characters, including letters, numbers, hyphens, dots, and underscores. The name cannot start with `AWS` or `aws`. | `string` | `""` | no |
+| <a name="input_tags"></a> [tags](#input\_tags) | (Optional) A map of tags to add to all resources. | `map(string)` | `{}` | no |
+| <a name="input_update_frequency"></a> [update\_frequency](#input\_update\_frequency) | (Optional) How often to publish updates to policy findings for the account. This includes publishing updates to AWS Security Hub and Amazon EventBridge (formerly called Amazon CloudWatch Events). Valid values are `15m`, `1h` or `6h`. Defaults to `15m`. | `string` | `"15m"` | no |
+
+## Outputs
+
+| Name | Description |
+|------|-------------|
+| <a name="output_created_at"></a> [created\_at](#output\_created\_at) | The date and time, in UTC and extended RFC 3339 format, when the Amazon Macie account was created. |
+| <a name="output_enabled"></a> [enabled](#output\_enabled) | Whether the macie account is eanbled. |
+| <a name="output_id"></a> [id](#output\_id) | The ID of the macie account. |
+| <a name="output_member_accounts"></a> [member\_accounts](#output\_member\_accounts) | The list of configruations for member accounts on the macie account. |
+| <a name="output_name"></a> [name](#output\_name) | The account ID of the macie account. |
+| <a name="output_service_role"></a> [service\_role](#output\_service\_role) | The Amazon Resource Name (ARN) of the service-linked role that allows Macie to monitor and analyze data in AWS resources for the account. |
+| <a name="output_update_frequency"></a> [update\_frequency](#output\_update\_frequency) | How often to publish updates to policy findings for the macie account. |
+| <a name="output_updated_at"></a> [updated\_at](#output\_updated\_at) | The date and time, in UTC and extended RFC 3339 format, of the most recent change to the status of the Macie account. |
+<!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->

--- a/modules/macie-account/main.tf
+++ b/modules/macie-account/main.tf
@@ -1,0 +1,98 @@
+locals {
+  metadata = {
+    package = "terraform-aws-security"
+    version = trimspace(file("${path.module}/../../VERSION"))
+    module  = basename(path.module)
+    name    = data.aws_caller_identity.this.account_id
+  }
+  module_tags = var.module_tags_enabled ? {
+    "module.terraform.io/package"   = local.metadata.package
+    "module.terraform.io/version"   = local.metadata.version
+    "module.terraform.io/name"      = local.metadata.module
+    "module.terraform.io/full-name" = "${local.metadata.package}/${local.metadata.module}"
+    "module.terraform.io/instance"  = local.metadata.name
+  } : {}
+}
+
+data "aws_caller_identity" "this" {}
+
+locals {
+  update_frequency = {
+    "15m" = "FIFTEEN_MINUTES"
+    "1h"  = "ONE_HOUR"
+    "6h"  = "SIX_HOURS"
+  }
+}
+
+###################################################
+# Macie Account
+###################################################
+
+resource "aws_macie2_account" "this" {
+  status = var.enabled ? "ENABLED" : "PAUSED"
+
+  finding_publishing_frequency = local.update_frequency[var.update_frequency]
+}
+
+
+###################################################
+# Member Accounts of Macie Account
+###################################################
+
+# TODO: Cannot delete member account from AWS Organization
+# https://github.com/hashicorp/terraform-provider-aws/issues/26219
+resource "aws_macie2_member" "this" {
+  for_each = {
+    for account in var.member_accounts :
+    account.account_id => account
+  }
+
+  account_id = each.key
+  email      = each.value.email
+  status     = try(each.value.enabled, true) ? "ENABLED" : "PAUSED"
+
+  ## Invitation
+  # invite                                = true
+  # invitation_message                    = "Message of the invitation"
+  # invitation_disable_email_notification = true
+
+  tags = merge(
+    {
+      "Name" = each.key
+    },
+    local.module_tags,
+    var.tags,
+    try(each.value.tags, {}),
+  )
+
+  # TODO: Bug for `email` parameter only when member is from organization
+  # https://github.com/hashicorp/terraform-provider-aws/issues/26218
+  lifecycle {
+    ignore_changes = [
+      email,
+    ]
+  }
+
+  depends_on = [
+    aws_macie2_account.this
+  ]
+}
+
+
+###################################################
+# S3 Bucket for Sensitive Data Discovery Results
+###################################################
+
+resource "aws_macie2_classification_export_configuration" "this" {
+  count = var.discovery_result != null ? 1 : 0
+
+  s3_destination {
+    bucket_name = var.discovery_result.s3_bucket
+    key_prefix  = try(var.discovery_result.s3_key_prefix, "")
+    kms_key_arn = var.discovery_result.encryption_kms_key
+  }
+
+  depends_on = [
+    aws_macie2_account.this,
+  ]
+}

--- a/modules/macie-account/outputs.tf
+++ b/modules/macie-account/outputs.tf
@@ -1,0 +1,60 @@
+output "id" {
+  description = "The ID of the macie account."
+  value       = aws_macie2_account.this.id
+}
+
+output "name" {
+  description = "The account ID of the macie account."
+  value       = local.metadata.name
+}
+
+output "enabled" {
+  description = "Whether the macie account is eanbled."
+  value       = aws_macie2_account.this.status == "ENABLED"
+}
+
+output "update_frequency" {
+  description = "How often to publish updates to policy findings for the macie account."
+  value = {
+    for k, v in local.update_frequency :
+    v => k
+  }[aws_macie2_account.this.finding_publishing_frequency]
+}
+
+output "service_role" {
+  description = "The Amazon Resource Name (ARN) of the service-linked role that allows Macie to monitor and analyze data in AWS resources for the account."
+  value       = aws_macie2_account.this.service_role
+}
+
+output "created_at" {
+  description = "The date and time, in UTC and extended RFC 3339 format, when the Amazon Macie account was created."
+  value       = aws_macie2_account.this.created_at
+}
+
+output "updated_at" {
+  description = "The date and time, in UTC and extended RFC 3339 format, of the most recent change to the status of the Macie account."
+  value       = aws_macie2_account.this.updated_at
+}
+
+output "member_accounts" {
+  description = <<EOF
+  The list of configruations for member accounts on the macie account.
+  EOF
+  value = {
+    for id, account in aws_macie2_member.this :
+    id => {
+      id      = account.id
+      arn     = account.arn
+      email   = account.email
+      enabled = account.status == "ENABLED"
+    }
+  }
+}
+
+# TODO
+# output "discovery_result" {
+#   description = <<EOF
+#   The configuration for discovery result location and encryption of the macie account.
+#   EOF
+#   value       = aws_macie2_classification_export_configuration.this
+# }

--- a/modules/macie-account/resource-group.tf
+++ b/modules/macie-account/resource-group.tf
@@ -1,0 +1,44 @@
+locals {
+  resource_group_name = (var.resource_group_name != ""
+    ? var.resource_group_name
+    : join(".", [
+      local.metadata.package,
+      local.metadata.module,
+      replace(local.metadata.name, "/[^a-zA-Z0-9_\\.-]/", "-"),
+    ])
+  )
+  resource_group_filters = [
+    for key, value in local.module_tags : {
+      "Key"    = key
+      "Values" = [value]
+    }
+  ]
+  resource_group_query = <<-JSON
+  {
+    "ResourceTypeFilters": [
+      "AWS::AllSupported"
+    ],
+    "TagFilters": ${jsonencode(local.resource_group_filters)}
+  }
+  JSON
+}
+
+resource "aws_resourcegroups_group" "this" {
+  count = (var.resource_group_enabled && var.module_tags_enabled) ? 1 : 0
+
+  name        = local.resource_group_name
+  description = var.resource_group_description
+
+  resource_query {
+    type  = "TAG_FILTERS_1_0"
+    query = local.resource_group_query
+  }
+
+  tags = merge(
+    {
+      "Name" = local.resource_group_name
+    },
+    local.module_tags,
+    var.tags,
+  )
+}

--- a/modules/macie-account/variables.tf
+++ b/modules/macie-account/variables.tf
@@ -1,0 +1,82 @@
+variable "enabled" {
+  description = "(Optional) Whether to enable Amazon Macie and start all Macie activities for the account. Defaults to `true`. Set `false` to suspend Macie, it stops monitoring your AWS environment and does not generate new findings. The existing findings remain intact and are not affected. Delete `aws_macie2_account` resource to disable Macie, it permanently deletes all of your existing findings, classification jobs, and other Macie resources."
+  type        = bool
+  default     = true
+  nullable    = false
+}
+
+variable "update_frequency" {
+  description = "(Optional) How often to publish updates to policy findings for the account. This includes publishing updates to AWS Security Hub and Amazon EventBridge (formerly called Amazon CloudWatch Events). Valid values are `15m`, `1h` or `6h`. Defaults to `15m`."
+  type        = string
+  default     = "15m"
+  nullable    = false
+
+  validation {
+    condition     = contains(["15m", "1h", "6h"], var.update_frequency)
+    error_message = "Valid values for `update_frequency` are `15m`, `1h` or `6h`."
+  }
+}
+
+variable "member_accounts" {
+  description = <<EOF
+  (Optional) A list of configurations for member accounts on the macie account. Each block of `member_accounts` as defined below.
+    (Required) `account_id` -
+    (Required) `email` -
+    (Optional) `enabled` - Whether to enable Amazon Macie and start all Macie activities for the member account.
+    (Optional) `tags` - A map of key-value pairs that specifies the tags to associate with the account in Amazon Macie.
+  EOF
+  type        = any
+  default     = []
+  nullable    = false
+}
+
+
+variable "discovery_result" {
+  description = <<EOF
+  (Optional) The configuration for discovery result location and encryption of the macie account. A `discovery_result` block as defined below.
+    (Required) `s3_bucket` - The name of the S3 bucket in which Amazon Macie exports the data discovery result.
+    (Optional) `s3_key_prefix` - The key prefix for the specified S3 bucket. Defaults to `""`.
+    (Required) `encryption_kms_key` - The Amazon Resource Name (ARN) of the KMS key to be used to encrypt the data.
+  EOF
+  type        = map(any)
+  default     = null
+}
+variable "tags" {
+  description = "(Optional) A map of tags to add to all resources."
+  type        = map(string)
+  default     = {}
+  nullable    = false
+}
+
+variable "module_tags_enabled" {
+  description = "(Optional) Whether to create AWS Resource Tags for the module informations."
+  type        = bool
+  default     = true
+  nullable    = false
+}
+
+
+###################################################
+# Resource Group
+###################################################
+
+variable "resource_group_enabled" {
+  description = "(Optional) Whether to create Resource Group to find and group AWS resources which are created by this module."
+  type        = bool
+  default     = true
+  nullable    = false
+}
+
+variable "resource_group_name" {
+  description = "(Optional) The name of Resource Group. A Resource Group name can have a maximum of 127 characters, including letters, numbers, hyphens, dots, and underscores. The name cannot start with `AWS` or `aws`."
+  type        = string
+  default     = ""
+  nullable    = false
+}
+
+variable "resource_group_description" {
+  description = "(Optional) The description of Resource Group."
+  type        = string
+  default     = "Managed by Terraform."
+  nullable    = false
+}

--- a/modules/macie-account/versions.tf
+++ b/modules/macie-account/versions.tf
@@ -1,0 +1,10 @@
+terraform {
+  required_version = ">= 1.2"
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = ">= 4.14"
+    }
+  }
+}


### PR DESCRIPTION
### Background

- Add `macie-account` module
- Add `macie-account-simple` example code.
- Update GitHub labels for `macie-account` module.