### PR TITLE
Move resource-group from module to resource

### DIFF
--- a/modules/access-analyzer/README.md
+++ b/modules/access-analyzer/README.md
@@ -17,11 +17,13 @@ This module creates following resources.
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | 4.23.0 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | 4.52.0 |
 
 ## Modules
 
-No modules.
+| Name | Source | Version |
+|------|--------|---------|
+| <a name="module_resource_group"></a> [resource\_group](#module\_resource\_group) | tedilabs/misc/aws//modules/resource-group | ~> 0.10.0 |
 
 ## Resources
 
@@ -29,7 +31,6 @@ No modules.
 |------|------|
 | [aws_accessanalyzer_analyzer.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/accessanalyzer_analyzer) | resource |
 | [aws_accessanalyzer_archive_rule.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/accessanalyzer_archive_rule) | resource |
-| [aws_resourcegroups_group.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/resourcegroups_group) | resource |
 
 ## Inputs
 

--- a/modules/access-analyzer/migrations.tf
+++ b/modules/access-analyzer/migrations.tf
@@ -1,0 +1,5 @@
+# 2023-02-01
+moved {
+  from = aws_resourcegroups_group.this[0]
+  to   = module.resource_group[0].aws_resourcegroups_group.this
+}

--- a/modules/access-analyzer/resource-group.tf
+++ b/modules/access-analyzer/resource-group.tf
@@ -7,37 +7,24 @@ locals {
       replace(local.metadata.name, "/[^a-zA-Z0-9_\\.-]/", "-"),
     ])
   )
-  resource_group_filters = [
-    for key, value in local.module_tags : {
-      "Key"    = key
-      "Values" = [value]
-    }
-  ]
-  resource_group_query = <<-JSON
-  {
-    "ResourceTypeFilters": [
-      "AWS::AllSupported"
-    ],
-    "TagFilters": ${jsonencode(local.resource_group_filters)}
-  }
-  JSON
 }
 
-resource "aws_resourcegroups_group" "this" {
+
+module "resource_group" {
+  source  = "tedilabs/misc/aws//modules/resource-group"
+  version = "~> 0.10.0"
+
   count = (var.resource_group_enabled && var.module_tags_enabled) ? 1 : 0
 
   name        = local.resource_group_name
   description = var.resource_group_description
 
-  resource_query {
-    type  = "TAG_FILTERS_1_0"
-    query = local.resource_group_query
+  query = {
+    resource_tags = local.module_tags
   }
 
+  module_tags_enabled = false
   tags = merge(
-    {
-      "Name" = local.resource_group_name
-    },
     local.module_tags,
     var.tags,
   )

--- a/modules/cloudtrail-trail/README.md
+++ b/modules/cloudtrail-trail/README.md
@@ -12,47 +12,67 @@ This module creates following resources.
 
 | Name | Version |
 |------|---------|
-| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.1 |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.2 |
 | <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 4.14 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | 4.14.0 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | 4.52.0 |
 
 ## Modules
 
-No modules.
+| Name | Source | Version |
+|------|--------|---------|
+| <a name="module_resource_group"></a> [resource\_group](#module\_resource\_group) | tedilabs/misc/aws//modules/resource-group | ~> 0.10.0 |
+| <a name="module_role"></a> [role](#module\_role) | tedilabs/account/aws//modules/iam-role | ~> 0.20.0 |
 
 ## Resources
 
 | Name | Type |
 |------|------|
-| [aws_resourcegroups_group.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/resourcegroups_group) | resource |
-| [aws_route53_resolver_firewall_config.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/route53_resolver_firewall_config) | resource |
-| [aws_route53_resolver_firewall_rule_group_association.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/route53_resolver_firewall_rule_group_association) | resource |
+| [aws_cloudtrail.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudtrail) | resource |
+| [aws_caller_identity.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/caller_identity) | data source |
+| [aws_iam_policy_document.cloudwatch](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
+| [aws_organizations_organization.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/organizations_organization) | data source |
+| [aws_partition.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/partition) | data source |
+| [aws_region.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/region) | data source |
 
 ## Inputs
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
-| <a name="input_vpc_id"></a> [vpc\_id](#input\_vpc\_id) | (Required) The ID of the VPC which the firewall belongs to. | `string` | n/a | yes |
-| <a name="input_fail_open_enabled"></a> [fail\_open\_enabled](#input\_fail\_open\_enabled) | (Optional) Determines how Route 53 Resolver handles queries during failures, for example when all traffic that is sent to DNS Firewall fails to receive a reply. By default, fail open is disabled, which means the failure mode is closed. This approach favors security over availability. DNS Firewall blocks queries that it is unable to evaluate properly. If you enable this option, the failure mode is open. This approach favors availability over security. DNS Firewall allows queries to proceed if it is unable to properly evaluate them. | `bool` | `false` | no |
+| <a name="input_delivery_s3_bucket"></a> [delivery\_s3\_bucket](#input\_delivery\_s3\_bucket) | (Required) The name of the S3 bucket designated for publishing log files. | `string` | n/a | yes |
+| <a name="input_name"></a> [name](#input\_name) | (Required) The name of the trail. The name can only contain uppercase letters, lowercase letters, numbers, periods (.), hyphens (-), and underscores (\_). | `string` | n/a | yes |
+| <a name="input_delivery_cloudwatch_logs_log_group"></a> [delivery\_cloudwatch\_logs\_log\_group](#input\_delivery\_cloudwatch\_logs\_log\_group) | (Optional) The name of the log group of CloudWatch Logs for log file delivery. | `string` | `null` | no |
+| <a name="input_delivery_s3_integrity_validation_enabled"></a> [delivery\_s3\_integrity\_validation\_enabled](#input\_delivery\_s3\_integrity\_validation\_enabled) | (Optional) To determine whether a log file was modified, deleted, or unchanged after AWS CloudTrail delivered it, use CloudTrail log file integrity validation. This feature is built using industry standard algorithms: SHA-256 for hashing and SHA-256 with RSA for digital signing. | `bool` | `true` | no |
+| <a name="input_delivery_s3_key_prefix"></a> [delivery\_s3\_key\_prefix](#input\_delivery\_s3\_key\_prefix) | (Optional) The key prefix for the specified S3 bucket. | `string` | `null` | no |
+| <a name="input_delivery_sns_topic"></a> [delivery\_sns\_topic](#input\_delivery\_sns\_topic) | (Optional) The name of the SNS topic for notification of log file delivery. | `string` | `null` | no |
+| <a name="input_enabled"></a> [enabled](#input\_enabled) | (Optional) Whether the trail starts the recording of AWS API calls and log file delivery. | `bool` | `true` | no |
+| <a name="input_insight_event"></a> [insight\_event](#input\_insight\_event) | (Optional) A configuration block for insight events logging to identify unusual operational activity. `insight_event` block as defined below.<br>    (Required) `enabled` - Whether the trail to log insight events.<br>    (Optional) `scopes` - A list of insight types to log on the trail. Valid values are `API_CALL_RATE` and `API_ERROR_RATE`. | <pre>object({<br>    enabled = bool<br>    scopes  = list(string)<br>  })</pre> | <pre>{<br>  "enabled": false,<br>  "scopes": []<br>}</pre> | no |
+| <a name="input_level"></a> [level](#input\_level) | (Optional) The level of the trail to decide whether the trail is an AWS Organizations trail. Organization trails log events for the master account and all member accounts. Can only be created in the organization master account. Valid values are `ACCOUNT` and `ORGANIZATION`. Use `ORGANIZATION` level in Organization master account. Defaults to `ACCOUNT`. | `string` | `"ACCOUNT"` | no |
+| <a name="input_management_event"></a> [management\_event](#input\_management\_event) | (Optional) A configuration block for management events logging to identify API activity for individual resources, or for all current and future resources in AWS account. `management_event` block as defined below.<br>    (Required) `enabled` - Whether the trail to log management events.<br>    (Optional) `scope` - The type of events to log. Valid values are `ALL`, `READ` and `WRITE`. Defaults to `ALL`.<br>    (Optional) `exclude_event_sources` - A set of event sources to exclude. Valid values are `kms.amazonaws.com` and `rdsdata.amazonaws.com`. `management_event.enabled` must be set to true to allow this. | <pre>object({<br>    enabled               = bool<br>    scope                 = string<br>    exclude_event_sources = list(string)<br>  })</pre> | <pre>{<br>  "enabled": true,<br>  "exclude_event_sources": [],<br>  "scope": "ALL"<br>}</pre> | no |
 | <a name="input_module_tags_enabled"></a> [module\_tags\_enabled](#input\_module\_tags\_enabled) | (Optional) Whether to create AWS Resource Tags for the module informations. | `bool` | `true` | no |
 | <a name="input_resource_group_description"></a> [resource\_group\_description](#input\_resource\_group\_description) | (Optional) The description of Resource Group. | `string` | `"Managed by Terraform."` | no |
 | <a name="input_resource_group_enabled"></a> [resource\_group\_enabled](#input\_resource\_group\_enabled) | (Optional) Whether to create Resource Group to find and group AWS resources which are created by this module. | `bool` | `true` | no |
 | <a name="input_resource_group_name"></a> [resource\_group\_name](#input\_resource\_group\_name) | (Optional) The name of Resource Group. A Resource Group name can have a maximum of 127 characters, including letters, numbers, hyphens, dots, and underscores. The name cannot start with `AWS` or `aws`. | `string` | `""` | no |
-| <a name="input_rule_groups"></a> [rule\_groups](#input\_rule\_groups) | (Optional) A list of rule groups associated with the firewall. Each value of `rule_group` block as defined below.<br>    (Required) `id` - The ID of the firewall rule group.<br>    (Required) `priority` - The setting that determines the processing order of the rule group among the rule groups that you associate with the specified VPC. DNS Firewall filters VPC traffic starting from the rule group with the lowest numeric priority setting.<br>    (Optional) `mutation_protection_enabled` - If enabled, this setting disallows modification or removal of the association, to help prevent against accidentally altering DNS firewall protections. | `any` | `[]` | no |
+| <a name="input_scope"></a> [scope](#input\_scope) | (Optional) The scope of the trail to decide whether the trail is multi-region trail. Supported values are `REGIONAL_WITH_GLOBAL`, `REGIONAL` or `ALL`. Defaults to `REGIONAL_WITH_GLOBAL`. | `string` | `"REGIONAL_WITH_GLOBAL"` | no |
 | <a name="input_tags"></a> [tags](#input\_tags) | (Optional) A map of tags to add to all resources. | `map(string)` | `{}` | no |
 
 ## Outputs
 
 | Name | Description |
 |------|-------------|
-| <a name="output_fail_open_enabled"></a> [fail\_open\_enabled](#output\_fail\_open\_enabled) | Whether the Route53 Resolver handles queries during failures. |
-| <a name="output_id"></a> [id](#output\_id) | The ID of the firewall configuration. |
-| <a name="output_owner_id"></a> [owner\_id](#output\_owner\_id) | The AWS Account ID of the owner of the VPC that this firewall applies to. |
-| <a name="output_rule_groups"></a> [rule\_groups](#output\_rule\_groups) | The configuration of rule groups associated with the firewall. |
-| <a name="output_vpc_id"></a> [vpc\_id](#output\_vpc\_id) | The VPC ID which the firewall applies to. |
+| <a name="output_arn"></a> [arn](#output\_arn) | The Amazon Resource Name (ARN) of the trail. |
+| <a name="output_delivery_channels"></a> [delivery\_channels](#output\_delivery\_channels) | Delivery channels of the trail. |
+| <a name="output_enabled"></a> [enabled](#output\_enabled) | Whether the trail is enabled. |
+| <a name="output_home_region"></a> [home\_region](#output\_home\_region) | The region in which the trail was created. |
+| <a name="output_iam_role"></a> [iam\_role](#output\_iam\_role) | The IAM Role for the CloudTrail trail. |
+| <a name="output_id"></a> [id](#output\_id) | The ID of the trail. |
+| <a name="output_insight_event"></a> [insight\_event](#output\_insight\_event) | A configuration for insight events logging of the trail. |
+| <a name="output_level"></a> [level](#output\_level) | The level of the trail to decide whether the trail is an AWS Organizations trail. |
+| <a name="output_management_event"></a> [management\_event](#output\_management\_event) | A configuration for management events logging of the trail. |
+| <a name="output_name"></a> [name](#output\_name) | The name of the trail. |
+| <a name="output_scope"></a> [scope](#output\_scope) | The scope of the trail to decide whether the trail is multi-region trail. |
 <!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->

--- a/modules/cloudtrail-trail/migrations.tf
+++ b/modules/cloudtrail-trail/migrations.tf
@@ -1,0 +1,5 @@
+# 2023-02-01
+moved {
+  from = aws_resourcegroups_group.this[0]
+  to   = module.resource_group[0].aws_resourcegroups_group.this
+}

--- a/modules/cloudtrail-trail/resource-group.tf
+++ b/modules/cloudtrail-trail/resource-group.tf
@@ -7,37 +7,24 @@ locals {
       replace(local.metadata.name, "/[^a-zA-Z0-9_\\.-]/", "-"),
     ])
   )
-  resource_group_filters = [
-    for key, value in local.module_tags : {
-      "Key"    = key
-      "Values" = [value]
-    }
-  ]
-  resource_group_query = <<-JSON
-  {
-    "ResourceTypeFilters": [
-      "AWS::AllSupported"
-    ],
-    "TagFilters": ${jsonencode(local.resource_group_filters)}
-  }
-  JSON
 }
 
-resource "aws_resourcegroups_group" "this" {
+
+module "resource_group" {
+  source  = "tedilabs/misc/aws//modules/resource-group"
+  version = "~> 0.10.0"
+
   count = (var.resource_group_enabled && var.module_tags_enabled) ? 1 : 0
 
   name        = local.resource_group_name
   description = var.resource_group_description
 
-  resource_query {
-    type  = "TAG_FILTERS_1_0"
-    query = local.resource_group_query
+  query = {
+    resource_tags = local.module_tags
   }
 
+  module_tags_enabled = false
   tags = merge(
-    {
-      "Name" = local.resource_group_name
-    },
     local.module_tags,
     var.tags,
   )

--- a/modules/cloudtrail-trail/versions.tf
+++ b/modules/cloudtrail-trail/versions.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = ">= 1.1"
+  required_version = ">= 1.2"
 
   required_providers {
     aws = {

--- a/modules/config-managed-rule/README.md
+++ b/modules/config-managed-rule/README.md
@@ -15,18 +15,20 @@ This module creates following resources.
 
 | Name | Version |
 |------|---------|
-| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.0 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 3.65 |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.2 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 4.14 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | 3.69.0 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | 4.52.0 |
 
 ## Modules
 
-No modules.
+| Name | Source | Version |
+|------|--------|---------|
+| <a name="module_resource_group"></a> [resource\_group](#module\_resource\_group) | tedilabs/misc/aws//modules/resource-group | ~> 0.10.0 |
 
 ## Resources
 
@@ -34,28 +36,27 @@ No modules.
 |------|------|
 | [aws_config_config_rule.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/config_config_rule) | resource |
 | [aws_config_organization_managed_rule.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/config_organization_managed_rule) | resource |
-| [aws_resourcegroups_group.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/resourcegroups_group) | resource |
 
 ## Inputs
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
-| <a name="input_source_rule"></a> [source\_rule](#input\_source\_rule) | The identifier for AWS Config managed rule. Use the format like `root-account-mfa-enabled` instead of predefiend format like `ROOT_ACCOUNT_MFA_ENABLED`. | `string` | n/a | yes |
-| <a name="input_description"></a> [description](#input\_description) | The description of the rule. Use default description if not provided. | `string` | `null` | no |
-| <a name="input_excluded_accounts"></a> [excluded\_accounts](#input\_excluded\_accounts) | A list of AWS account identifiers to exclude from the rule. Only need when `level` is configured with value `ORGANIZATION`. | `list(string)` | `[]` | no |
-| <a name="input_level"></a> [level](#input\_level) | Choose to create a rule across all accounts in your Organization. Valid values are `ACCOUNT` and `ORGANIZATION`. Use `ORGANIZATION` level in Organization master account or delegated administrator accounts. | `string` | `"ACCOUNT"` | no |
-| <a name="input_module_tags_enabled"></a> [module\_tags\_enabled](#input\_module\_tags\_enabled) | Whether to create AWS Resource Tags for the module informations. | `bool` | `true` | no |
-| <a name="input_name"></a> [name](#input\_name) | The name of the rule. Use default rule name if not provided. | `string` | `null` | no |
-| <a name="input_parameters"></a> [parameters](#input\_parameters) | A map of parameters that is passed to the AWS Config rule Lambda function. | `any` | `{}` | no |
-| <a name="input_resource_group_description"></a> [resource\_group\_description](#input\_resource\_group\_description) | The description of Resource Group. | `string` | `"Managed by Terraform."` | no |
-| <a name="input_resource_group_enabled"></a> [resource\_group\_enabled](#input\_resource\_group\_enabled) | Whether to create Resource Group to find and group AWS resources which are created by this module. | `bool` | `true` | no |
-| <a name="input_resource_group_name"></a> [resource\_group\_name](#input\_resource\_group\_name) | The name of Resource Group. A Resource Group name can have a maximum of 127 characters, including letters, numbers, hyphens, dots, and underscores. The name cannot start with `AWS` or `aws`. | `string` | `""` | no |
-| <a name="input_resource_id"></a> [resource\_id](#input\_resource\_id) | The ID of the only AWS resource that you want to trigger an evaluation for the rule. If you specify this, you must specify only one resource type for `resource_types`. Only need when `scope` is configured with value `RESOURCES`. | `string` | `null` | no |
-| <a name="input_resource_tag"></a> [resource\_tag](#input\_resource\_tag) | The tag that are applied to only those AWS resources that you want you want to trigger an evaluation for the rule. You can configure with only `key` or a set of `key` and `value`. Only need when `scope` is configured with value `TAGS`. | `map(string)` | `{}` | no |
-| <a name="input_resource_types"></a> [resource\_types](#input\_resource\_types) | A list of resource types of only those AWS resources that you want to trigger an evaluation for the rule. For example, `AWS::EC2::Instance` or `AWS::CloudTrail::Trail`. Only need when `scope` is configured with value `RESOURCES`. | `list(string)` | `[]` | no |
-| <a name="input_schedule_frequency"></a> [schedule\_frequency](#input\_schedule\_frequency) | The frequency with which AWS Config runs evaluations for a rule. Use default value if not provided. Valid values are `1h`, `3h`, `6h`, `12h`, or `24h`. | `string` | `null` | no |
-| <a name="input_scope"></a> [scope](#input\_scope) | Choose when evaluations will occur. Valid values are `ALL_CHANGES`, `RESOURCES`, or `TAGS`. | `string` | `"RESOURCES"` | no |
-| <a name="input_tags"></a> [tags](#input\_tags) | A map of tags to add to all resources. | `map(string)` | `{}` | no |
+| <a name="input_source_rule"></a> [source\_rule](#input\_source\_rule) | (Required) The identifier for AWS Config managed rule. Use the format like `root-account-mfa-enabled` instead of predefiend format like `ROOT_ACCOUNT_MFA_ENABLED`. | `string` | n/a | yes |
+| <a name="input_description"></a> [description](#input\_description) | (Optional) The description of the rule. Use default description if not provided. | `string` | `null` | no |
+| <a name="input_excluded_accounts"></a> [excluded\_accounts](#input\_excluded\_accounts) | (Optional) A list of AWS account identifiers to exclude from the rule. Only need when `level` is configured with value `ORGANIZATION`. | `list(string)` | `[]` | no |
+| <a name="input_level"></a> [level](#input\_level) | (Optional) Choose to create a rule across all accounts in your Organization. Valid values are `ACCOUNT` and `ORGANIZATION`. Use `ORGANIZATION` level in Organization master account or delegated administrator accounts. | `string` | `"ACCOUNT"` | no |
+| <a name="input_module_tags_enabled"></a> [module\_tags\_enabled](#input\_module\_tags\_enabled) | (Optional) Whether to create AWS Resource Tags for the module informations. | `bool` | `true` | no |
+| <a name="input_name"></a> [name](#input\_name) | (Optional) The name of the rule. Use default rule name if not provided. | `string` | `null` | no |
+| <a name="input_parameters"></a> [parameters](#input\_parameters) | (Optional) A map of parameters that is passed to the AWS Config rule Lambda function. | `any` | `{}` | no |
+| <a name="input_resource_group_description"></a> [resource\_group\_description](#input\_resource\_group\_description) | (Optional) The description of Resource Group. | `string` | `"Managed by Terraform."` | no |
+| <a name="input_resource_group_enabled"></a> [resource\_group\_enabled](#input\_resource\_group\_enabled) | (Optional) Whether to create Resource Group to find and group AWS resources which are created by this module. | `bool` | `true` | no |
+| <a name="input_resource_group_name"></a> [resource\_group\_name](#input\_resource\_group\_name) | (Optional) The name of Resource Group. A Resource Group name can have a maximum of 127 characters, including letters, numbers, hyphens, dots, and underscores. The name cannot start with `AWS` or `aws`. | `string` | `""` | no |
+| <a name="input_resource_id"></a> [resource\_id](#input\_resource\_id) | (Optional) The ID of the only AWS resource that you want to trigger an evaluation for the rule. If you specify this, you must specify only one resource type for `resource_types`. Only need when `scope` is configured with value `RESOURCES`. | `string` | `null` | no |
+| <a name="input_resource_tag"></a> [resource\_tag](#input\_resource\_tag) | (Optional) The tag that are applied to only those AWS resources that you want you want to trigger an evaluation for the rule. You can configure with only `key` or a set of `key` and `value`. Only need when `scope` is configured with value `TAGS`. | `map(string)` | `{}` | no |
+| <a name="input_resource_types"></a> [resource\_types](#input\_resource\_types) | (Optional) A list of resource types of only those AWS resources that you want to trigger an evaluation for the rule. For example, `AWS::EC2::Instance` or `AWS::CloudTrail::Trail`. Only need when `scope` is configured with value `RESOURCES`. | `list(string)` | `[]` | no |
+| <a name="input_schedule_frequency"></a> [schedule\_frequency](#input\_schedule\_frequency) | (Optional) The frequency with which AWS Config runs evaluations for a rule. Use default value if not provided. Valid values are `1h`, `3h`, `6h`, `12h`, or `24h`. | `string` | `null` | no |
+| <a name="input_scope"></a> [scope](#input\_scope) | (Optional) Choose when evaluations will occur. Valid values are `ALL_CHANGES`, `RESOURCES`, or `TAGS`. | `string` | `"RESOURCES"` | no |
+| <a name="input_tags"></a> [tags](#input\_tags) | (Optional) A map of tags to add to all resources. | `map(string)` | `{}` | no |
 
 ## Outputs
 

--- a/modules/config-managed-rule/migrations.tf
+++ b/modules/config-managed-rule/migrations.tf
@@ -1,0 +1,5 @@
+# 2023-02-01
+moved {
+  from = aws_resourcegroups_group.this[0]
+  to   = module.resource_group[0].aws_resourcegroups_group.this
+}

--- a/modules/config-managed-rule/resource-group.tf
+++ b/modules/config-managed-rule/resource-group.tf
@@ -7,37 +7,24 @@ locals {
       replace(local.metadata.name, "/[^a-zA-Z0-9_\\.-]/", "-"),
     ])
   )
-  resource_group_filters = [
-    for key, value in local.module_tags : {
-      "Key"    = key
-      "Values" = [value]
-    }
-  ]
-  resource_group_query = <<-JSON
-  {
-    "ResourceTypeFilters": [
-      "AWS::AllSupported"
-    ],
-    "TagFilters": ${jsonencode(local.resource_group_filters)}
-  }
-  JSON
 }
 
-resource "aws_resourcegroups_group" "this" {
+
+module "resource_group" {
+  source  = "tedilabs/misc/aws//modules/resource-group"
+  version = "~> 0.10.0"
+
   count = (var.resource_group_enabled && var.module_tags_enabled) ? 1 : 0
 
   name        = local.resource_group_name
   description = var.resource_group_description
 
-  resource_query {
-    type  = "TAG_FILTERS_1_0"
-    query = local.resource_group_query
+  query = {
+    resource_tags = local.module_tags
   }
 
+  module_tags_enabled = false
   tags = merge(
-    {
-      "Name" = local.resource_group_name
-    },
     local.module_tags,
     var.tags,
   )

--- a/modules/config-managed-rule/versions.tf
+++ b/modules/config-managed-rule/versions.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = ">= 1.1"
+  required_version = ">= 1.2"
 
   required_providers {
     aws = {

--- a/modules/config-recorder/README.md
+++ b/modules/config-recorder/README.md
@@ -16,21 +16,22 @@ This module creates following resources.
 
 | Name | Version |
 |------|---------|
-| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.0 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 3.65 |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.2 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 4.14 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | 3.69.0 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | 4.52.0 |
 
 ## Modules
 
 | Name | Source | Version |
 |------|--------|---------|
-| <a name="module_role__aggregator"></a> [role\_\_aggregator](#module\_role\_\_aggregator) | tedilabs/account/aws//modules/iam-role | 0.18.3 |
-| <a name="module_role__recorder"></a> [role\_\_recorder](#module\_role\_\_recorder) | tedilabs/account/aws//modules/iam-role | 0.18.3 |
+| <a name="module_resource_group"></a> [resource\_group](#module\_resource\_group) | tedilabs/misc/aws//modules/resource-group | ~> 0.10.0 |
+| <a name="module_role__aggregator"></a> [role\_\_aggregator](#module\_role\_\_aggregator) | tedilabs/account/aws//modules/iam-role | ~> 0.20.0 |
+| <a name="module_role__recorder"></a> [role\_\_recorder](#module\_role\_\_recorder) | tedilabs/account/aws//modules/iam-role | ~> 0.20.0 |
 
 ## Resources
 
@@ -42,7 +43,6 @@ This module creates following resources.
 | [aws_config_configuration_recorder.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/config_configuration_recorder) | resource |
 | [aws_config_configuration_recorder_status.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/config_configuration_recorder_status) | resource |
 | [aws_config_delivery_channel.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/config_delivery_channel) | resource |
-| [aws_resourcegroups_group.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/resourcegroups_group) | resource |
 | [aws_caller_identity.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/caller_identity) | data source |
 | [aws_iam_policy_document.aggregation](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
 | [aws_iam_policy_document.delivery](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
@@ -51,23 +51,23 @@ This module creates following resources.
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
-| <a name="input_delivery_s3_bucket"></a> [delivery\_s3\_bucket](#input\_delivery\_s3\_bucket) | The name of the S3 bucket used to store the configuration history. | `string` | n/a | yes |
-| <a name="input_account_aggregations"></a> [account\_aggregations](#input\_account\_aggregations) | A list of configurations to aggregate config data from individual accounts. Supported properties for each configuration are `name`, `account_ids` and `regions`. Aggregate from all supported regions if `regions` is missing. | `list(any)` | `[]` | no |
-| <a name="input_authorized_aggregators"></a> [authorized\_aggregators](#input\_authorized\_aggregators) | A list of Authorized aggregators to allow an aggregator account and region to collect AWS Config configuration and compliance data. | <pre>list(object({<br>    account_id = string<br>    region     = string<br>  }))</pre> | `[]` | no |
-| <a name="input_custom_resource_types"></a> [custom\_resource\_types](#input\_custom\_resource\_types) | A list that specifies the types of AWS resources for which AWS Config records configuration changes. For example, `AWS::EC2::Instance` or `AWS::CloudTrail::Trail`. Only need when `scope` is confirued with value `CUSTOM`. | `list(string)` | `[]` | no |
-| <a name="input_delivery_frequency"></a> [delivery\_frequency](#input\_delivery\_frequency) | The frequency with which AWS Config recurringly delivers configuration snapshots. Valid values are `1h`, `3h`, `6h`, `12h`, or `24h`. | `string` | `null` | no |
-| <a name="input_delivery_s3_key_prefix"></a> [delivery\_s3\_key\_prefix](#input\_delivery\_s3\_key\_prefix) | The key prefix for the specified S3 bucket. | `string` | `null` | no |
-| <a name="input_delivery_s3_sse_kms_key"></a> [delivery\_s3\_sse\_kms\_key](#input\_delivery\_s3\_sse\_kms\_key) | The ARN of the AWS KMS key used to encrypt objects delivered by AWS Config. Must belong to the same Region as the destination S3 bucket. | `string` | `null` | no |
-| <a name="input_delivery_sns_topic"></a> [delivery\_sns\_topic](#input\_delivery\_sns\_topic) | The ARN of the SNS topic that AWS Config delivers notifications to. | `string` | `null` | no |
-| <a name="input_enabled"></a> [enabled](#input\_enabled) | Whether the configuration recorder should be enabled or disabled. | `bool` | `true` | no |
-| <a name="input_module_tags_enabled"></a> [module\_tags\_enabled](#input\_module\_tags\_enabled) | Whether to create AWS Resource Tags for the module informations. | `bool` | `true` | no |
-| <a name="input_name"></a> [name](#input\_name) | The name of the recorder. Defaults to `default`. Changing it recreates the resource. | `string` | `"default"` | no |
-| <a name="input_organization_aggregation"></a> [organization\_aggregation](#input\_organization\_aggregation) | The configuration to aggregate config data from organization accounts. Supported properties are `enabled` and `regions`. Aggregate from all supported regions if `regions` is missing. | `any` | `{}` | no |
-| <a name="input_resource_group_description"></a> [resource\_group\_description](#input\_resource\_group\_description) | The description of Resource Group. | `string` | `"Managed by Terraform."` | no |
-| <a name="input_resource_group_enabled"></a> [resource\_group\_enabled](#input\_resource\_group\_enabled) | Whether to create Resource Group to find and group AWS resources which are created by this module. | `bool` | `true` | no |
-| <a name="input_resource_group_name"></a> [resource\_group\_name](#input\_resource\_group\_name) | The name of Resource Group. A Resource Group name can have a maximum of 127 characters, including letters, numbers, hyphens, dots, and underscores. The name cannot start with `AWS` or `aws`. | `string` | `""` | no |
-| <a name="input_scope"></a> [scope](#input\_scope) | Specifies the scope of AWS Config configuration recorder. Supported values are `REGIONAL_WITH_GLOBAL`, `REGIONAL`, or `CUSTOM`. | `string` | `"REGIONAL"` | no |
-| <a name="input_tags"></a> [tags](#input\_tags) | A map of tags to add to all resources. | `map(string)` | `{}` | no |
+| <a name="input_delivery_s3_bucket"></a> [delivery\_s3\_bucket](#input\_delivery\_s3\_bucket) | (Required) The name of the S3 bucket used to store the configuration history. | `string` | n/a | yes |
+| <a name="input_account_aggregations"></a> [account\_aggregations](#input\_account\_aggregations) | (Optional) A list of configurations to aggregate config data from individual accounts. Supported properties for each configuration are `name`, `account_ids` and `regions`. Aggregate from all supported regions if `regions` is missing. | `list(any)` | `[]` | no |
+| <a name="input_authorized_aggregators"></a> [authorized\_aggregators](#input\_authorized\_aggregators) | (Optional) A list of Authorized aggregators to allow an aggregator account and region to collect AWS Config configuration and compliance data. | <pre>list(object({<br>    account_id = string<br>    region     = string<br>  }))</pre> | `[]` | no |
+| <a name="input_custom_resource_types"></a> [custom\_resource\_types](#input\_custom\_resource\_types) | (Optional) A list that specifies the types of AWS resources for which AWS Config records configuration changes. For example, `AWS::EC2::Instance` or `AWS::CloudTrail::Trail`. Only need when `scope` is confirued with value `CUSTOM`. | `list(string)` | `[]` | no |
+| <a name="input_delivery_frequency"></a> [delivery\_frequency](#input\_delivery\_frequency) | (Optional) The frequency with which AWS Config recurringly delivers configuration snapshots. Valid values are `1h`, `3h`, `6h`, `12h`, or `24h`. | `string` | `null` | no |
+| <a name="input_delivery_s3_key_prefix"></a> [delivery\_s3\_key\_prefix](#input\_delivery\_s3\_key\_prefix) | (Optional) The key prefix for the specified S3 bucket. | `string` | `null` | no |
+| <a name="input_delivery_s3_sse_kms_key"></a> [delivery\_s3\_sse\_kms\_key](#input\_delivery\_s3\_sse\_kms\_key) | (Optional) The ARN of the AWS KMS key used to encrypt objects delivered by AWS Config. Must belong to the same Region as the destination S3 bucket. | `string` | `null` | no |
+| <a name="input_delivery_sns_topic"></a> [delivery\_sns\_topic](#input\_delivery\_sns\_topic) | (Optional) The ARN of the SNS topic that AWS Config delivers notifications to. | `string` | `null` | no |
+| <a name="input_enabled"></a> [enabled](#input\_enabled) | (Optional) Whether the configuration recorder should be enabled or disabled. | `bool` | `true` | no |
+| <a name="input_module_tags_enabled"></a> [module\_tags\_enabled](#input\_module\_tags\_enabled) | (Optional) Whether to create AWS Resource Tags for the module informations. | `bool` | `true` | no |
+| <a name="input_name"></a> [name](#input\_name) | (Optional) The name of the recorder. Defaults to `default`. Changing it recreates the resource. | `string` | `"default"` | no |
+| <a name="input_organization_aggregation"></a> [organization\_aggregation](#input\_organization\_aggregation) | (Optional) The configuration to aggregate config data from organization accounts. Supported properties are `enabled` and `regions`. Aggregate from all supported regions if `regions` is missing. | `any` | `{}` | no |
+| <a name="input_resource_group_description"></a> [resource\_group\_description](#input\_resource\_group\_description) | (Optional) The description of Resource Group. | `string` | `"Managed by Terraform."` | no |
+| <a name="input_resource_group_enabled"></a> [resource\_group\_enabled](#input\_resource\_group\_enabled) | (Optional) Whether to create Resource Group to find and group AWS resources which are created by this module. | `bool` | `true` | no |
+| <a name="input_resource_group_name"></a> [resource\_group\_name](#input\_resource\_group\_name) | (Optional) The name of Resource Group. A Resource Group name can have a maximum of 127 characters, including letters, numbers, hyphens, dots, and underscores. The name cannot start with `AWS` or `aws`. | `string` | `""` | no |
+| <a name="input_scope"></a> [scope](#input\_scope) | (Optional) Specifies the scope of AWS Config configuration recorder. Supported values are `REGIONAL_WITH_GLOBAL`, `REGIONAL`, or `CUSTOM`. | `string` | `"REGIONAL"` | no |
+| <a name="input_tags"></a> [tags](#input\_tags) | (Optional) A map of tags to add to all resources. | `map(string)` | `{}` | no |
 
 ## Outputs
 

--- a/modules/config-recorder/migrations.tf
+++ b/modules/config-recorder/migrations.tf
@@ -1,0 +1,5 @@
+# 2023-02-01
+moved {
+  from = aws_resourcegroups_group.this[0]
+  to   = module.resource_group[0].aws_resourcegroups_group.this
+}

--- a/modules/config-recorder/resource-group.tf
+++ b/modules/config-recorder/resource-group.tf
@@ -7,37 +7,24 @@ locals {
       replace(local.metadata.name, "/[^a-zA-Z0-9_\\.-]/", "-"),
     ])
   )
-  resource_group_filters = [
-    for key, value in local.module_tags : {
-      "Key"    = key
-      "Values" = [value]
-    }
-  ]
-  resource_group_query = <<-JSON
-  {
-    "ResourceTypeFilters": [
-      "AWS::AllSupported"
-    ],
-    "TagFilters": ${jsonencode(local.resource_group_filters)}
-  }
-  JSON
 }
 
-resource "aws_resourcegroups_group" "this" {
+
+module "resource_group" {
+  source  = "tedilabs/misc/aws//modules/resource-group"
+  version = "~> 0.10.0"
+
   count = (var.resource_group_enabled && var.module_tags_enabled) ? 1 : 0
 
   name        = local.resource_group_name
   description = var.resource_group_description
 
-  resource_query {
-    type  = "TAG_FILTERS_1_0"
-    query = local.resource_group_query
+  query = {
+    resource_tags = local.module_tags
   }
 
+  module_tags_enabled = false
   tags = merge(
-    {
-      "Name" = local.resource_group_name
-    },
     local.module_tags,
     var.tags,
   )

--- a/modules/config-recorder/versions.tf
+++ b/modules/config-recorder/versions.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = ">= 1.1"
+  required_version = ">= 1.2"
 
   required_providers {
     aws = {

--- a/modules/macie-account/README.md
+++ b/modules/macie-account/README.md
@@ -18,11 +18,13 @@ This module creates following resources.
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | 4.25.0 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | 4.52.0 |
 
 ## Modules
 
-No modules.
+| Name | Source | Version |
+|------|--------|---------|
+| <a name="module_resource_group"></a> [resource\_group](#module\_resource\_group) | tedilabs/misc/aws//modules/resource-group | ~> 0.10.0 |
 
 ## Resources
 
@@ -31,7 +33,6 @@ No modules.
 | [aws_macie2_account.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/macie2_account) | resource |
 | [aws_macie2_classification_export_configuration.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/macie2_classification_export_configuration) | resource |
 | [aws_macie2_member.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/macie2_member) | resource |
-| [aws_resourcegroups_group.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/resourcegroups_group) | resource |
 | [aws_caller_identity.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/caller_identity) | data source |
 
 ## Inputs

--- a/modules/macie-account/migrations.tf
+++ b/modules/macie-account/migrations.tf
@@ -1,0 +1,5 @@
+# 2023-02-01
+moved {
+  from = aws_resourcegroups_group.this[0]
+  to   = module.resource_group[0].aws_resourcegroups_group.this
+}

--- a/modules/macie-account/resource-group.tf
+++ b/modules/macie-account/resource-group.tf
@@ -7,37 +7,24 @@ locals {
       replace(local.metadata.name, "/[^a-zA-Z0-9_\\.-]/", "-"),
     ])
   )
-  resource_group_filters = [
-    for key, value in local.module_tags : {
-      "Key"    = key
-      "Values" = [value]
-    }
-  ]
-  resource_group_query = <<-JSON
-  {
-    "ResourceTypeFilters": [
-      "AWS::AllSupported"
-    ],
-    "TagFilters": ${jsonencode(local.resource_group_filters)}
-  }
-  JSON
 }
 
-resource "aws_resourcegroups_group" "this" {
+
+module "resource_group" {
+  source  = "tedilabs/misc/aws//modules/resource-group"
+  version = "~> 0.10.0"
+
   count = (var.resource_group_enabled && var.module_tags_enabled) ? 1 : 0
 
   name        = local.resource_group_name
   description = var.resource_group_description
 
-  resource_query {
-    type  = "TAG_FILTERS_1_0"
-    query = local.resource_group_query
+  query = {
+    resource_tags = local.module_tags
   }
 
+  module_tags_enabled = false
   tags = merge(
-    {
-      "Name" = local.resource_group_name
-    },
     local.module_tags,
     var.tags,
   )


### PR DESCRIPTION
### :wave: Background
<!-- Please explain the background or motivation for this change. -->

- Use module instead of a resource for `resource_group`