### PR TITLE
chore: update copyright year to 2025

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,4 +134,4 @@ Like this project? Follow the repository on [GitHub](https://github.com/tedilabs
 
 Provided under the terms of the [Apache License](LICENSE).
 
-Copyright © 2021-2023, [Byungjin Park](https://www.posquit0.com).
+Copyright © 2021-2025, [Byungjin Park](https://www.posquit0.com).


### PR DESCRIPTION
## Summary
Update the copyright year in README.md from 2021-2023 to 2021-2025.

## Changes
- Updated copyright period in README.md to reflect the current year (2025)